### PR TITLE
Ignore exception

### DIFF
--- a/multigen/loader.py
+++ b/multigen/loader.py
@@ -21,7 +21,10 @@ class Loader:
                     if 'controlnet' in additional_args:
                         components.pop('controlnet')
                     return cls(**components, **additional_args)
-                components.pop('controlnet')
+                try:
+                    components.pop('controlnet')
+                except Exception as e:
+                    pass
                 return cls(**components, **additional_args)
 
 


### PR DESCRIPTION
@noskill , this line of code caused exception for some users (`components.pop('controlnet')` -> `KeyError`). I'm not sure how to reproduce it, but I saw it twice. I'm not sure if popping control net from components is needed always. Since it's your code, please, analyze what can be the cause and solution. For now, I just made the exception to be ignored.