### PR TITLE
fix random number generator in session

### DIFF
--- a/multigen/sessions.py
+++ b/multigen/sessions.py
@@ -55,8 +55,8 @@ class GenSession:
             self.last_index = self.confg.count - 1
             self.last_conf = {**inputs}
             # TODO: multiple inputs?
-            # inputs['generator'] = torch.Generator().manual_seed(inputs['generator'])
-            inputs['generator'] = torch.cuda.manual_seed(inputs['generator'])
+            inputs['generator'] = torch.Generator().manual_seed(inputs['generator'])
+
             image = self.pipe.gen(inputs)
             if save_img:
                 self.last_img_name = self.get_last_file_prefix() + ".png"


### PR DESCRIPTION
remove clip_skip implementation, clip_skip is implemented in diffusers for non-community pipelines and also for lpw pipelines for SDXL

torch.cuda.manual_seed returns None so we always pass None to pipeline

https://pytorch.org/docs/stable/_modules/torch/cuda/random.html#manual_seed

This PR replaces torch.cuda.manual_seed with torch.Generator()