### PR TITLE
use sequential cpu offload for limited gpu ram

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ psutil
 sentencepiece
 protobuf
 accelerate
-optimum-quanto
+optimum-quanto==0.2.4

--- a/tests/test_worker_flux.py
+++ b/tests/test_worker_flux.py
@@ -68,7 +68,7 @@ class WorkerTestCase(unittest.TestCase):
             nonlocal c
             c += 1
         
-        num_runs = 25
+        num_runs = 15
         for i in range(num_runs):
             if len(sessions) - 1 < i:
                 i %= len(sessions)


### PR DESCRIPTION
use cpu offload if device has < 23 gb of gpu ram, use quantitation otherwise