### PR TITLE
fix the base class for cnet

### DIFF
--- a/multigen/pipes.py
+++ b/multigen/pipes.py
@@ -670,8 +670,8 @@ class Cond2ImPipe(BasePipe):
     """
     Image to image generation with ControlNet
     """
-    _class = StableDiffusionControlNetImg2ImgPipeline
-    _classxl = StableDiffusionXLControlNetImg2ImgPipeline
+    _class = StableDiffusionControlNetPipeline #StableDiffusionControlNetImg2ImgPipeline
+    _classxl = StableDiffusionXLControlNetPipeline #StableDiffusionXLControlNetImg2ImgPipeline
     _autopipeline = DiffusionPipeline
     _classflux = FluxControlNetImg2ImgPipeline
 
@@ -811,7 +811,7 @@ class Cond2ImPipe(BasePipe):
                 if c in cmodels:
                     cnets.append(ControlNet.from_pretrained(cpath+cmodels[c]))
                 else:
-                    cnets.append(ControlNet.from_pretrained(c, torch_dtype=torch_dtype))
+                    cnets.append(ControlNet.from_pretrained(c, torch_dtype=dtype))
         if offload_device is not None:
             # controlnet should be on the same device where main model is working
             dev = torch.device('cuda', offload_device)


### PR DESCRIPTION
@noskill ,
`StableDiffusionControlNetImg2ImgPipeline` and `StableDiffusionXLControlNetImg2ImgPipeline` classes don't rise an exception, but don't work correctly for `Cond2Im` and `CIm2Im`. I'm returning correct classes here. If it affects any of the children classes, these classes should just redefine `_class` and `_classxl`